### PR TITLE
Resolve major performance issue

### DIFF
--- a/Helpers/CUCoreUtils.cs
+++ b/Helpers/CUCoreUtils.cs
@@ -899,8 +899,9 @@ namespace CUCoreLib.Helpers
             if (IsKrokMpChatFocused())
                 return true;
 
-            return Resources.FindObjectsOfTypeAll<TMP_InputField>()
-                .Any(field => field != null && field.isFocused);
+            var selected = EventSystem.current?.currentSelectedGameObject;
+		    var inputField = selected != null ? selected.GetComponent<TMP_InputField>() : null;
+		    return inputField != null && inputField.isFocused;
         }
 
         private static bool IsKrokMpChatFocused()

--- a/Helpers/CUCoreUtils.cs
+++ b/Helpers/CUCoreUtils.cs
@@ -12,7 +12,6 @@ using TMPro;
 using UnityEngine;
 using CompressionLevel = System.IO.Compression.CompressionLevel;
 using Object = UnityEngine.Object;
-using UnityEngine;
 using UnityEngine.EventSystems;
 
 namespace CUCoreLib.Helpers

--- a/Helpers/CUCoreUtils.cs
+++ b/Helpers/CUCoreUtils.cs
@@ -12,6 +12,8 @@ using TMPro;
 using UnityEngine;
 using CompressionLevel = System.IO.Compression.CompressionLevel;
 using Object = UnityEngine.Object;
+using UnityEngine;
+using UnityEngine.EventSystems;
 
 namespace CUCoreLib.Helpers
 {

--- a/Helpers/CUCoreUtils.cs
+++ b/Helpers/CUCoreUtils.cs
@@ -54,6 +54,13 @@ namespace CUCoreLib.Helpers
 
             public string KeyName => GetFriendlyKeyName(KeyCode);
 
+            public bool IsPressed()
+            {
+                if (!Input.GetKeyDown(KeyCode))
+                    return false;
+                return !ShouldDisableFriendlyKeybind(entry);
+            }
+
             public static implicit operator KeyCode(FriendlyKeybind keybind)
             {
                 return keybind != null ? keybind.KeyCode : KeyCode.None;
@@ -842,9 +849,6 @@ namespace CUCoreLib.Helpers
             var liveSetting = Settings.Get<SettingKeybind>(entry.ActionId);
             if (liveSetting != null)
                 entry.CurrentKey = liveSetting.value;
-
-            if (ShouldDisableFriendlyKeybind(entry))
-                return KeyCode.None;
 
             return entry.CurrentKey;
         }

--- a/Helpers/CUCoreUtils.cs
+++ b/Helpers/CUCoreUtils.cs
@@ -904,8 +904,7 @@ namespace CUCoreLib.Helpers
             if (IsKrokMpChatFocused())
                 return true;
 
-            var selected = EventSystem.current?.currentSelectedGameObject;
-		    var inputField = selected != null ? selected.GetComponent<TMP_InputField>() : null;
+            var inputField = EventSystem.current?.currentSelectedGameObject?.GetComponent<TMP_InputField>();
 		    return inputField != null && inputField.isFocused;
         }
 


### PR DESCRIPTION
This does 2 things:
* Fix a huge slow down in IsFriendlyKeybindInputFieldBlocked where it was iterating all resources instead just getting the selected game object. This was dropping me to single digit FPS.
* Add IsPressed() to FriendlyKeybind which checks if the key is pressed at all before running the checks. This prevents running the checks for each keybind every frame when it's completely unnecessary. **This also changes the behavior of KeyCode and KeyName to not perform disable checks and not switch to KeyCode.None when they would be disabled.** Either an internal check is needing for this optimization (current changes) or a separate public IsDisabled() method should be added and the KeyCode should remain static so the same Input.GetKeyDown followed by the checks can be done externally.

Feedback is welcome as I'm new to this.