### PR TITLE
perf: reduce allocations in hot paths (reflection cache, render buffers, LINQ elimination)

### DIFF
--- a/Patches/ItemRegistryPatches.cs
+++ b/Patches/ItemRegistryPatches.cs
@@ -171,10 +171,14 @@ namespace CUCoreLib.Patches
         {
             if (Item.allItems == null || Item.allItems.Count == 0) return;
 
-            var filteredIds = itemIds != null
-                ? new HashSet<string>(itemIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()),
-                    StringComparer.OrdinalIgnoreCase)
-                : null;
+            HashSet<string> filteredIds = null;
+            if (itemIds != null)
+            {
+                filteredIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var rawId in itemIds)
+                    if (!string.IsNullOrWhiteSpace(rawId))
+                        filteredIds.Add(rawId.Trim());
+            }
 
             foreach (var item in Item.allItems.ToArray())
             {
@@ -422,7 +426,13 @@ namespace CUCoreLib.Patches
                     wat.stack = CopyLiquidStacks(def.defaultContents);
 
                 if (def.capacity > 0f)
-                    item.condition = Mathf.Clamp01(wat.stack.Sum(liquid => liquid.amount) / def.capacity);
+                {
+                    var totalAmount = 0f;
+                    for (var si = 0; si < wat.stack.Count; si++)
+                        if (wat.stack[si] != null)
+                            totalAmount += wat.stack[si].amount;
+                    item.condition = Mathf.Clamp01(totalAmount / def.capacity);
+                }
             }
 
             // Injectables (Syringes)
@@ -441,7 +451,13 @@ namespace CUCoreLib.Patches
                         wat.stack.Add(new LiquidStack(liquid.liquidId, liquid.amount));
 
                 if (def.Syringe.Capacity > 0f)
-                    item.condition = Mathf.Clamp01(wat.stack.Sum(liquid => liquid.amount) / def.Syringe.Capacity);
+                {
+                    var totalAmount = 0f;
+                    for (var si = 0; si < wat.stack.Count; si++)
+                        if (wat.stack[si] != null)
+                            totalAmount += wat.stack[si].amount;
+                    item.condition = Mathf.Clamp01(totalAmount / def.Syringe.Capacity);
+                }
             }
         }
 
@@ -484,12 +500,17 @@ namespace CUCoreLib.Patches
 
         private static SpriteRenderer FindLiquidFillRenderer(WaterContainerItem waterContainer)
         {
-            return waterContainer == null
-                ? null
-                : waterContainer.GetComponentsInChildren<SpriteRenderer>(true)
-                    .FirstOrDefault(renderer => renderer != null && renderer.transform.parent == waterContainer.transform &&
-                                                string.Equals(renderer.gameObject.name, "LiquidFill",
-                                                    StringComparison.Ordinal));
+            if (waterContainer == null) return null;
+
+            var renderers = waterContainer.GetComponentsInChildren<SpriteRenderer>(true);
+            for (var i = 0; i < renderers.Length; i++)
+            {
+                var renderer = renderers[i];
+                if (renderer != null && renderer.transform.parent == waterContainer.transform &&
+                    string.Equals(renderer.gameObject.name, "LiquidFill", StringComparison.Ordinal))
+                    return renderer;
+            }
+            return null;
         }
 
         internal static void ApplyContainerProperties(Item item, CustomItemInfo def)
@@ -515,9 +536,12 @@ namespace CUCoreLib.Patches
             var copy = new List<LiquidStack>();
             if (source == null) return copy;
 
-            copy.AddRange(from liquid in source
-                where liquid != null
-                select new LiquidStack(liquid.liquidId, liquid.amount));
+            for (var i = 0; i < source.Count; i++)
+            {
+                var liquid = source[i];
+                if (liquid != null)
+                    copy.Add(new LiquidStack(liquid.liquidId, liquid.amount));
+            }
 
             return copy;
         }

--- a/Registries/ItemRegistry.cs
+++ b/Registries/ItemRegistry.cs
@@ -64,6 +64,9 @@ namespace CUCoreLib.Registries
         private static readonly ConditionalWeakTable<Item, ItemCustomDataState> ItemCustomDataStates =
             new ConditionalWeakTable<Item, ItemCustomDataState>();
 
+        private static readonly Dictionary<Type, FieldInfo[]> PublicInstanceFieldCache =
+            new Dictionary<Type, FieldInfo[]>();
+
         public static void Register(string id, ItemInfo info, Sprite icon, int spawnFrequency = 1)
         {
             if (string.IsNullOrWhiteSpace(id))
@@ -604,7 +607,7 @@ namespace CUCoreLib.Registries
 
         private static string BuildInvalidLiquidStackWarningKey(string itemId, string sourceName, int index, string liquidId)
         {
-            return (itemId ?? string.Empty) + "|" + sourceName + "|" + index + "|" + liquidId;
+            return string.Concat(itemId ?? string.Empty, "|", sourceName, "|", index.ToString(), "|", liquidId);
         }
 
         public static bool TryGetCustomInfo(string id, out CustomItemInfo info)
@@ -765,6 +768,7 @@ namespace CUCoreLib.Registries
         internal static Sprite GetIcon(CustomItemInfo info)
         {
             if (info == null) return null;
+            if (info.Icon != null && IsValidIcon(info.Icon)) return info.Icon;
 
             NormalizeIcon(info);
             return info.Icon;
@@ -976,16 +980,24 @@ namespace CUCoreLib.Registries
                 "' has no valid icon sprite. Runtime will use CUCoreLib's missing-item fallback until you assign one.");
         }
 
-        private static IEnumerable<FieldInfo> GetPublicInstanceFields(Type type)
+        private static FieldInfo[] GetPublicInstanceFields(Type type)
         {
+            if (PublicInstanceFieldCache.TryGetValue(type, out var cached))
+                return cached;
+
             var seen = new HashSet<string>();
+            var fields = new List<FieldInfo>();
             for (var current = type;
                  current != null && typeof(ItemInfo).IsAssignableFrom(current);
                  current = current.BaseType)
                 foreach (var field in current.GetFields(BindingFlags.Public | BindingFlags.Instance |
                                                         BindingFlags.DeclaredOnly))
                     if (seen.Add(field.Name))
-                        yield return field;
+                        fields.Add(field);
+
+            var result = fields.ToArray();
+            PublicInstanceFieldCache[type] = result;
+            return result;
         }
 
         private static void ApplyDefaultOverrides(CustomItemInfo info)

--- a/Registries/LiquidTileRegistry.cs
+++ b/Registries/LiquidTileRegistry.cs
@@ -41,6 +41,8 @@ namespace CUCoreLib.Registries
         private static readonly FieldInfo LiquidParticlesField =
             AccessTools.Field(typeof(FluidManager), "liquidParticles");
 
+        private static List<ParticleSystem.Particle>[] _renderParticleBuffers;
+
         private static bool _summaryLogged;
 
         static LiquidTileRegistry()
@@ -300,9 +302,18 @@ namespace CUCoreLib.Registries
             if (particles == null || particles.Count == 0) return false;
 
             var range = manager.SimulationRange();
-            var byType = new List<ParticleSystem.Particle>[particles.Count];
-            for (var i = 0; i < byType.Length; i++)
-                byType[i] = new List<ParticleSystem.Particle>();
+            if (_renderParticleBuffers == null || _renderParticleBuffers.Length != particles.Count)
+            {
+                _renderParticleBuffers = new List<ParticleSystem.Particle>[particles.Count];
+                for (var i = 0; i < _renderParticleBuffers.Length; i++)
+                    _renderParticleBuffers[i] = new List<ParticleSystem.Particle>();
+            }
+            else
+            {
+                for (var i = 0; i < _renderParticleBuffers.Length; i++)
+                    _renderParticleBuffers[i].Clear();
+            }
+            var byType = _renderParticleBuffers;
 
             for (var x = range.Item1.min; x < range.Item1.max; x++)
             {


### PR DESCRIPTION
## Summary

This PR introduces several performance optimizations targeting allocation-heavy hot paths in CUCoreLib. The changes are backwards-compatible and do not alter public API behavior.

### Changes

**1. Cache reflection in `ItemRegistry.GetPublicInstanceFields`** (`Registries/ItemRegistry.cs`)
- Added `Dictionary<Type, FieldInfo[]>` cache to avoid repeated reflection calls
- Method now returns cached `FieldInfo[]` instead of using `yield return` iterator with per-call `HashSet`
- Eliminates: iterator state machine allocation, HashSet allocation, repeated `GetFields()` calls per type

**2. Fast path in `ItemRegistry.GetIcon`** (`Registries/ItemRegistry.cs`)
- Added early return when `info.Icon` is already valid, skipping `NormalizeIcon()` call
- Reduces unnecessary `IsValidIcon()` checks on the common path

**3. Cache render particle buffers in `LiquidTileRegistry.RenderFluids`** (`Registries/LiquidTileRegistry.cs`)
- Cached `List<ParticleSystem.Particle>[]` array and inner lists as static fields
- Reuses buffers across frames instead of allocating new ones every frame
- Eliminates: array allocation + N list allocations per frame in the fluid render loop

**4. Replace LINQ with loops in `ItemRegistryPatches`** (`Patches/ItemRegistryPatches.cs`)
- `ApplyCustomItemComponents`: Replaced `.Sum()` with manual accumulation loop (2 sites)
- `RefreshLiveInstances`: Replaced `.Where().Select()` chain with direct `HashSet` population
- `FindLiquidFillRenderer`: Replaced `.FirstOrDefault()` with `for` loop and early return
- `CopyLiquidStacks`: Replaced LINQ query expression with `for` loop
- Eliminates: per-call enumerator allocations, delegate closures, iterator state machines

### Impact

These optimizations target code paths that run frequently during gameplay:
- **Item registration**: Reflection caching reduces cost from O(n×m) to O(n) for n items with m fields
- **Fluid rendering**: Eliminates per-frame heap allocations in the render loop
- **Item spawning**: Reduces allocations in `ApplyCustomItemComponents` which runs on every item spawn
- **Content reload**: Reduces allocations in `RefreshLiveInstances` during mod reload