### PR TITLE
perf: reduce per-frame allocations and cache reflection lookups in registries

### DIFF
--- a/Patches/ItemRegistryPatches.cs
+++ b/Patches/ItemRegistryPatches.cs
@@ -171,10 +171,14 @@ namespace CUCoreLib.Patches
         {
             if (Item.allItems == null || Item.allItems.Count == 0) return;
 
-            var filteredIds = itemIds != null
-                ? new HashSet<string>(itemIds.Where(id => !string.IsNullOrWhiteSpace(id)).Select(id => id.Trim()),
-                    StringComparer.OrdinalIgnoreCase)
-                : null;
+            HashSet<string> filteredIds = null;
+            if (itemIds != null)
+            {
+                filteredIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var rawId in itemIds)
+                    if (!string.IsNullOrWhiteSpace(rawId))
+                        filteredIds.Add(rawId.Trim());
+            }
 
             foreach (var item in Item.allItems.ToArray())
             {
@@ -422,7 +426,13 @@ namespace CUCoreLib.Patches
                     wat.stack = CopyLiquidStacks(def.defaultContents);
 
                 if (def.capacity > 0f)
-                    item.condition = Mathf.Clamp01(wat.stack.Sum(liquid => liquid.amount) / def.capacity);
+                {
+                    var totalAmount = 0f;
+                    for (var si = 0; si < wat.stack.Count; si++)
+                        if (wat.stack[si] != null)
+                            totalAmount += wat.stack[si].amount;
+                    item.condition = Mathf.Clamp01(totalAmount / def.capacity);
+                }
             }
 
             // Injectables (Syringes)
@@ -441,7 +451,13 @@ namespace CUCoreLib.Patches
                         wat.stack.Add(new LiquidStack(liquid.liquidId, liquid.amount));
 
                 if (def.Syringe.Capacity > 0f)
-                    item.condition = Mathf.Clamp01(wat.stack.Sum(liquid => liquid.amount) / def.Syringe.Capacity);
+                {
+                    var totalAmount = 0f;
+                    for (var si = 0; si < wat.stack.Count; si++)
+                        if (wat.stack[si] != null)
+                            totalAmount += wat.stack[si].amount;
+                    item.condition = Mathf.Clamp01(totalAmount / def.Syringe.Capacity);
+                }
             }
         }
 
@@ -484,12 +500,17 @@ namespace CUCoreLib.Patches
 
         private static SpriteRenderer FindLiquidFillRenderer(WaterContainerItem waterContainer)
         {
-            return waterContainer == null
-                ? null
-                : waterContainer.GetComponentsInChildren<SpriteRenderer>(true)
-                    .FirstOrDefault(renderer => renderer != null && renderer.transform.parent == waterContainer.transform &&
-                                                string.Equals(renderer.gameObject.name, "LiquidFill",
-                                                    StringComparison.Ordinal));
+            if (waterContainer == null) return null;
+
+            var renderers = waterContainer.GetComponentsInChildren<SpriteRenderer>(true);
+            for (var i = 0; i < renderers.Length; i++)
+            {
+                var renderer = renderers[i];
+                if (renderer != null && renderer.transform.parent == waterContainer.transform &&
+                    string.Equals(renderer.gameObject.name, "LiquidFill", StringComparison.Ordinal))
+                    return renderer;
+            }
+            return null;
         }
 
         internal static void ApplyContainerProperties(Item item, CustomItemInfo def)
@@ -515,9 +536,12 @@ namespace CUCoreLib.Patches
             var copy = new List<LiquidStack>();
             if (source == null) return copy;
 
-            copy.AddRange(from liquid in source
-                where liquid != null
-                select new LiquidStack(liquid.liquidId, liquid.amount));
+            for (var i = 0; i < source.Count; i++)
+            {
+                var liquid = source[i];
+                if (liquid != null)
+                    copy.Add(new LiquidStack(liquid.liquidId, liquid.amount));
+            }
 
             return copy;
         }

--- a/Registries/ItemRegistry.cs
+++ b/Registries/ItemRegistry.cs
@@ -64,6 +64,9 @@ namespace CUCoreLib.Registries
         private static readonly ConditionalWeakTable<Item, ItemCustomDataState> ItemCustomDataStates =
             new ConditionalWeakTable<Item, ItemCustomDataState>();
 
+        private static readonly Dictionary<Type, FieldInfo[]> PublicInstanceFieldCache =
+            new Dictionary<Type, FieldInfo[]>();
+
         public static void Register(string id, ItemInfo info, Sprite icon, int spawnFrequency = 1)
         {
             if (string.IsNullOrWhiteSpace(id))
@@ -604,7 +607,7 @@ namespace CUCoreLib.Registries
 
         private static string BuildInvalidLiquidStackWarningKey(string itemId, string sourceName, int index, string liquidId)
         {
-            return (itemId ?? string.Empty) + "|" + sourceName + "|" + index + "|" + liquidId;
+            return string.Concat(itemId ?? string.Empty, "|", sourceName, "|", index.ToString(), "|", liquidId);
         }
 
         public static bool TryGetCustomInfo(string id, out CustomItemInfo info)
@@ -765,6 +768,7 @@ namespace CUCoreLib.Registries
         internal static Sprite GetIcon(CustomItemInfo info)
         {
             if (info == null) return null;
+            if (info.Icon != null && IsValidIcon(info.Icon)) return info.Icon;
 
             NormalizeIcon(info);
             return info.Icon;
@@ -976,16 +980,24 @@ namespace CUCoreLib.Registries
                 "' has no valid icon sprite. Runtime will use CUCoreLib's missing-item fallback until you assign one.");
         }
 
-        private static IEnumerable<FieldInfo> GetPublicInstanceFields(Type type)
+        private static FieldInfo[] GetPublicInstanceFields(Type type)
         {
+            if (PublicInstanceFieldCache.TryGetValue(type, out var cached))
+                return cached;
+
             var seen = new HashSet<string>();
+            var fields = new List<FieldInfo>();
             for (var current = type;
                  current != null && typeof(ItemInfo).IsAssignableFrom(current);
                  current = current.BaseType)
                 foreach (var field in current.GetFields(BindingFlags.Public | BindingFlags.Instance |
                                                         BindingFlags.DeclaredOnly))
                     if (seen.Add(field.Name))
-                        yield return field;
+                        fields.Add(field);
+
+            var result = fields.ToArray();
+            PublicInstanceFieldCache[type] = result;
+            return result;
         }
 
         private static void ApplyDefaultOverrides(CustomItemInfo info)

--- a/Registries/LiquidTileRegistry.cs
+++ b/Registries/LiquidTileRegistry.cs
@@ -41,6 +41,8 @@ namespace CUCoreLib.Registries
         private static readonly FieldInfo LiquidParticlesField =
             AccessTools.Field(typeof(FluidManager), "liquidParticles");
 
+        private static List<ParticleSystem.Particle>[] _renderParticleBuffers;
+
         private static bool _summaryLogged;
 
         static LiquidTileRegistry()
@@ -300,9 +302,18 @@ namespace CUCoreLib.Registries
             if (particles == null || particles.Count == 0) return false;
 
             var range = manager.SimulationRange();
-            var byType = new List<ParticleSystem.Particle>[particles.Count];
-            for (var i = 0; i < byType.Length; i++)
-                byType[i] = new List<ParticleSystem.Particle>();
+            if (_renderParticleBuffers == null || _renderParticleBuffers.Length != particles.Count)
+            {
+                _renderParticleBuffers = new List<ParticleSystem.Particle>[particles.Count];
+                for (var i = 0; i < _renderParticleBuffers.Length; i++)
+                    _renderParticleBuffers[i] = new List<ParticleSystem.Particle>();
+            }
+            else
+            {
+                for (var i = 0; i < _renderParticleBuffers.Length; i++)
+                    _renderParticleBuffers[i].Clear();
+            }
+            var byType = _renderParticleBuffers;
 
             for (var x = range.Item1.min; x < range.Item1.max; x++)
             {

--- a/Registries/LiquidTileRegistry.cs
+++ b/Registries/LiquidTileRegistry.cs
@@ -41,7 +41,8 @@ namespace CUCoreLib.Registries
         private static readonly FieldInfo LiquidParticlesField =
             AccessTools.Field(typeof(FluidManager), "liquidParticles");
 
-        private static List<ParticleSystem.Particle>[] _renderParticleBuffers;
+        private static ParticleSystem.Particle[][] _renderParticleBuffers;
+        private static int[] _renderParticleCounts;
 
         private static bool _summaryLogged;
 
@@ -302,18 +303,18 @@ namespace CUCoreLib.Registries
             if (particles == null || particles.Count == 0) return false;
 
             var range = manager.SimulationRange();
+
             if (_renderParticleBuffers == null || _renderParticleBuffers.Length != particles.Count)
             {
-                _renderParticleBuffers = new List<ParticleSystem.Particle>[particles.Count];
+                _renderParticleBuffers = new ParticleSystem.Particle[particles.Count][];
+                _renderParticleCounts = new int[particles.Count];
                 for (var i = 0; i < _renderParticleBuffers.Length; i++)
-                    _renderParticleBuffers[i] = new List<ParticleSystem.Particle>();
+                    _renderParticleBuffers[i] = new ParticleSystem.Particle[64];
             }
-            else
-            {
-                for (var i = 0; i < _renderParticleBuffers.Length; i++)
-                    _renderParticleBuffers[i].Clear();
-            }
+            for (var i = 0; i < _renderParticleCounts.Length; i++)
+                _renderParticleCounts[i] = 0;
             var byType = _renderParticleBuffers;
+            var counts = _renderParticleCounts;
 
             for (var x = range.Item1.min; x < range.Item1.max; x++)
             {
@@ -328,7 +329,16 @@ namespace CUCoreLib.Registries
                     var openTop = manager.GetLiquid(x, y + 1) == 0 &&
                                   (manager.GetLiquid(x + 1, y) == 0 || manager.GetLiquid(x - 1, y) == 0);
                     var color = TryGetDisplayColor(worldByte, out var customColor) ? customColor : Color.white;
-                    byType[index].Add(new ParticleSystem.Particle
+
+                    var list = byType[index];
+                    if (counts[index] >= list.Length)
+                    {
+                        var enlarged = new ParticleSystem.Particle[list.Length * 2];
+                        Array.Copy(list, enlarged, list.Length);
+                        list = enlarged;
+                        byType[index] = list;
+                    }
+                    list[counts[index]++] = new ParticleSystem.Particle
                     {
                         position = WorldGeneration.world.BlockToWorldPos(new Vector2Int(x, y)) +
                                    (openTop ? new Vector2(0f, -0.3125f) : Vector2.zero),
@@ -336,12 +346,12 @@ namespace CUCoreLib.Registries
                         remainingLifetime = 999f,
                         startColor = color,
                         startSize3D = new Vector2(1.25f, openTop ? 0.625f : 1.25f)
-                    });
+                    };
                 }
             }
 
             for (var i = 0; i < particles.Count; i++)
-                particles[i].SetParticles(byType[i].ToArray());
+                particles[i].SetParticles(byType[i], counts[i]);
 
             return true;
         }


### PR DESCRIPTION
Hello, I am very sorry, I do not speak English, so I used AI assistance to generate this message, very sorry.

### Summary
This PR cuts avoidable work in a few registry hot paths — most notably the per-frame `RenderFluids` pass — by reusing buffers instead of re-allocating every call, and by caching the per-type reflection scan it was repeating. The code changes are mechanical rewrites; behavior is unchanged except where noted below.

### Benchmarks (in-game, net472, 3 runs)
| Path | Before | After |
|---|---|---|
| RenderFluids (41 types, ~200 each) | 2.1–3.2 ms/iter, 48–137 KB alloc/iter | ~0.19 ms/iter, ~0 B alloc/iter |
| GetPublicInstanceFields | ~0.011 ms/iter, ~5.6 KB alloc/iter | ~0.0001 ms/iter, ~0 B alloc/iter |

Validated with a full world load — item/fluid rendering behaves normally, no errors.

### Note
The two `Sum` rewrites now skip `null` entries in a liquid stack as a defensive guard (the previous LINQ form would throw on `null`). If you'd prefer pure-equivalent rewrites, that guard is easy to remove.

Happy to split or simplify to taste, e.g. drop the micro cleanups and keep only the `RenderFluids` + reflection-cache changes for a tighter diff.