### PR TITLE
Fix server broadcast, status snapshot deserialization and receiver re-registration

### DIFF
--- a/CUCoreLib.cs
+++ b/CUCoreLib.cs
@@ -171,7 +171,7 @@ namespace CUCoreLib
             KrokMpCompatibilityPatches.Install(harmony);
             QoLUnknownCompatibilityPatches.Install(harmony);
 
-            MultiplayerBridge.Initialize();
+            MultiplayerBridge.Initialize(harmony);
             MultiplayerSyncRegistry.ScheduleInitialSnapshot();
 
             Logger.LogInfo("CUCoreLib is ready to sit in the background.");

--- a/Networking/MultiplayerBridge.cs
+++ b/Networking/MultiplayerBridge.cs
@@ -10,6 +10,7 @@ using BepInEx.Bootstrap;
 using CUCoreLib.Helpers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using UnityEngine;
 
 namespace CUCoreLib.Networking
 {
@@ -77,6 +78,33 @@ namespace CUCoreLib.Networking
         private static MethodInfo _serverAnnounceGameStartMethod;
         private static object _reliableOrdered;
         private static object _reliableUnordered;
+
+        // KrokMP's Net.Server_SendToClients overloads take `in` (byref) parameters.
+        // Mono's reflection invoke requires every byref argument in the argument
+        // array to be the EXACT parameter type (it must be able to write the value
+        // back through the pointer), while CUCoreLib passes the AllClientIds /
+        // AllClientIdsExceptHost collections whose runtime type is List<knetid>.
+        // That never matches the byref IEnumerable<knetid> parameter exactly, so a
+        // plain _serverSendToClientsMethod.Invoke(...) throws ArgumentException and
+        // every server-side Broadcast silently fails. _serverSendToClientsInvoker is
+        // a DynamicMethod with plain (non-byref) parameters that forwards the call
+        // with proper managed pointers; because all of its parameters are value
+        // parameters, MethodInfo.Invoke only performs a normal assignability check.
+        // _serverSendToClientsInvokerSource tracks which MethodInfo the invoker was
+        // built for, because TryResolveRuntime re-resolves the field on its retry
+        // schedule and the invoker must be rebuilt whenever the source changes.
+        private static MethodInfo _serverSendToClientsInvoker;
+        private static MethodInfo _serverSendToClientsInvokerSource;
+        private static int _dynamicMethodCounter;
+
+        // KrokMP's Net.ShutdownReset() clears the SERVER_MESSAGE_HANDLERS /
+        // CLIENT_MESSAGE_HANDLERS tables where CUCoreLib registers its 56420/56421
+        // receivers. KrokMP does not re-run any third-party registration when the
+        // next transport starts, so CUCoreLib re-installs its receivers itself:
+        // every send goes through EnsureReceiversForActiveSession, and a watchdog
+        // coroutine covers the receiver side (e.g. a host that has not sent
+        // anything yet when the first client request arrives).
+        private static bool _sessionWatchdogStarted;
 
         public static bool IsAvailable { get; private set; }
 
@@ -189,6 +217,7 @@ namespace CUCoreLib.Networking
             if (TryResolveRuntime())
             {
                 InstallReceivers();
+                StartSessionWatchdog();
                 IsAvailable = true;
                 CUCoreLibPlugin.Log?.LogInfo("CUCoreLib multiplayer bridge is ready.");
                 return;
@@ -352,6 +381,12 @@ namespace CUCoreLib.Networking
         private static bool SendEnvelope(ushort messageId, JObject envelope, bool reliable, uint clientId,
             object targets)
         {
+            // KrokMP's ShutdownReset() wipes our 56420/56421 receivers when a
+            // session ends. Make sure they exist again for the active session
+            // BEFORE sending, so that the response to this very message cannot be
+            // dropped by the local side.
+            EnsureReceiversForActiveSession();
+
             if (!TryBuildWriter(messageId, envelope, out var writer)) return false;
 
             var delivery = reliable ? _reliableOrdered : _reliableUnordered;
@@ -359,7 +394,15 @@ namespace CUCoreLib.Networking
             {
                 if (targets != null)
                 {
-                    _serverSendToClientsMethod.Invoke(null, new[] { delivery, writer, targets });
+                    // Never invoke _serverSendToClientsMethod directly: KrokMP
+                    // declares it with `in` parameters, and Mono's reflection
+                    // invoke requires exact types for byref arguments, which the
+                    // List<knetid> targets collection can never satisfy. The
+                    // invoker wraps the call with plain value parameters.
+                    var invoker = GetSendToClientsInvoker();
+                    if (invoker == null) return false;
+
+                    invoker.Invoke(null, new[] { delivery, writer, targets });
                     return true;
                 }
 
@@ -521,6 +564,58 @@ namespace CUCoreLib.Networking
             return handlers.Contains(messageId);
         }
 
+        private static void StartSessionWatchdog()
+        {
+            if (_sessionWatchdogStarted) return;
+
+            _sessionWatchdogStarted = true;
+            CUCoreUtils.StartCoroutine(SessionWatchdogRoutine());
+        }
+
+        private static IEnumerator SessionWatchdogRoutine()
+        {
+            // KrokMP's ShutdownReset() clears the handler tables that hold our
+            // receivers, so after every session restart the receivers are missing
+            // until re-installed. Sending paths self-heal through
+            // EnsureReceiversForActiveSession, but a host that only ever RECEIVES
+            // (a client request arriving before the host sends anything) would
+            // drop messages forever without a periodic check. One realtime second
+            // is enough: clients reconnect on a much slower timescale, and the
+            // initial snapshot request has its own retry as a further backstop.
+            while (true)
+            {
+                try
+                {
+                    EnsureReceiversForActiveSession();
+                }
+                catch (Exception ex)
+                {
+                    CUCoreLibPlugin.Log?.LogWarning("CUCoreLib multiplayer session watchdog tick failed.\n" + ex);
+                }
+
+                yield return new WaitForSecondsRealtime(1f);
+            }
+        }
+
+        private static void EnsureReceiversForActiveSession()
+        {
+            if (!IsAvailable || !IsRunning || _netType == null) return;
+
+            // A session is running but our message ids are missing from KrokMP's
+            // handler tables: ShutdownReset wiped them and the session was
+            // recreated afterwards. InstallReceivers is idempotent (it checks
+            // IsReceiverRegistered before registering), so re-running it is safe
+            // at any time. Only when receivers actually had to be re-installed do
+            // we tell the sync registry about the new session, which guarantees
+            // its one-shot snapshot guards are reset exactly once per session.
+            if (!IsReceiverRegistered(_netType, "SERVER_MESSAGE_HANDLERS", RequestMessageId) ||
+                !IsReceiverRegistered(_netType, "CLIENT_MESSAGE_HANDLERS", ResponseMessageId))
+            {
+                InstallReceivers();
+                MultiplayerSyncRegistry.HandleNewKrokMpSessionDetected();
+            }
+        }
+
         private static Delegate CreateReceiverDelegate(MethodInfo registerMethod, MethodInfo helperMethod)
         {
             if (registerMethod == null || helperMethod == null) return null;
@@ -570,6 +665,7 @@ namespace CUCoreLib.Networking
         {
             if (!TryResolveRuntime()) return;
             InstallReceivers();
+            StartSessionWatchdog();
             IsAvailable = true;
             CUCoreLibPlugin.Log?.LogInfo("CUCoreLib multiplayer bridge is ready.");
         }
@@ -613,8 +709,7 @@ namespace CUCoreLib.Networking
                 new[] { _deliveryMethodType, _writerType });
             _serverSendToMethod = ResolveMethod(_netType, new[] { "Server_SendTo" },
                 new[] { _deliveryMethodType, _writerType, typeof(uint) });
-            _serverSendToClientsMethod = ResolveMethod(_netType, new[] { "Server_SendToClients" },
-                new[] { _deliveryMethodType, _writerType, typeof(IEnumerable) });
+            _serverSendToClientsMethod = ResolveSendToClientsMethod(_netType, _deliveryMethodType, _writerType);
             _registerServerReceiverMethod = ResolveMethod(_netType,
                 new[] { "RegisterServerReceiver", "RegisterServerReciever" }, new[] { typeof(ushort), null });
             _registerClientReceiverMethod = ResolveMethod(_netType,
@@ -663,6 +758,145 @@ namespace CUCoreLib.Networking
             }
 
             return null;
+        }
+
+        private static MethodInfo ResolveSendToClientsMethod(Type netType, Type deliveryMethodType,
+            Type writerType)
+        {
+            // KrokMP ships several Server_SendToClients overloads:
+            //   (in DeliveryMethod, in NetDataWriter, in knetid)
+            //   (in DeliveryMethod, in NetDataWriter, in IReadOnlyList<NetPlayer>)
+            //   (in DeliveryMethod, in NetDataWriter, in IEnumerable<knetid>)
+            // A loose typeof(IEnumerable) filter matches every one of them, and the
+            // enumeration order of GetMethods is not contractual, so the generic
+            // ResolveMethod call could pick the IReadOnlyList<NetPlayer> overload
+            // even though Broadcast passes a List<knetid>. Pick the overload whose
+            // target collection is an IEnumerable<T> of a client-id-like element
+            // type (knetid is a struct carrying a public "id" field) - that is the
+            // overload CUCoreLib actually needs, and it makes the runtime cast
+            // inside the DynamicMethod invoker succeed for the real target lists.
+            var candidates = netType
+                .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)
+                .Where(candidate => string.Equals(candidate.Name, "Server_SendToClients", StringComparison.Ordinal))
+                .Select(candidate => new { Method = candidate, Parameters = candidate.GetParameters() })
+                .Where(candidate => candidate.Parameters.Length == 3 &&
+                                    ParameterMatches(deliveryMethodType, candidate.Parameters[0].ParameterType) &&
+                                    ParameterMatches(writerType, candidate.Parameters[1].ParameterType))
+                .ToArray();
+
+            foreach (var candidate in candidates)
+            {
+                var targetsType = UnwrapByRef(candidate.Parameters[2].ParameterType);
+                if (targetsType == null || !targetsType.IsGenericType) continue;
+                if (targetsType.GetGenericTypeDefinition() != typeof(IEnumerable<>)) continue;
+
+                var elementType = targetsType.GetGenericArguments()[0];
+                if (IsClientIdType(elementType)) return candidate.Method;
+            }
+
+            foreach (var candidate in candidates)
+            {
+                var targetsType = UnwrapByRef(candidate.Parameters[2].ParameterType);
+                if (targetsType == null || !targetsType.IsGenericType) continue;
+                if (targetsType.GetGenericTypeDefinition() != typeof(IEnumerable<>)) continue;
+
+                var elementType = targetsType.GetGenericArguments()[0];
+                if (elementType.IsValueType) return candidate.Method;
+            }
+
+            // Fall back to the legacy loose resolution so a future KrokMP
+            // signature change degrades to the previous behaviour instead of
+            // failing the whole bridge resolution outright.
+            return ResolveMethod(netType, new[] { "Server_SendToClients" },
+                new[] { deliveryMethodType, writerType, typeof(IEnumerable) });
+        }
+
+        private static MethodInfo GetSendToClientsInvoker()
+        {
+            // TryResolveRuntime re-runs on the retry schedule and re-resolves the
+            // field every time, so the invoker must be rebuilt whenever the
+            // underlying MethodInfo reference changes.
+            if (_serverSendToClientsInvoker != null &&
+                ReferenceEquals(_serverSendToClientsInvokerSource, _serverSendToClientsMethod))
+                return _serverSendToClientsInvoker;
+
+            _serverSendToClientsInvoker = BuildSendToClientsInvoker(_serverSendToClientsMethod);
+            _serverSendToClientsInvokerSource = _serverSendToClientsMethod;
+            return _serverSendToClientsInvoker;
+        }
+
+        private static MethodInfo BuildSendToClientsInvoker(MethodInfo method)
+        {
+            if (method == null) return null;
+
+            var parameters = method.GetParameters();
+            if (parameters.Length != 3) return method;
+
+            // If the resolved overload is already declared with plain value
+            // parameters, MethodInfo.Invoke performs a standard assignability
+            // check on each argument and no wrapper is needed.
+            if (!parameters.Any(parameter => parameter.ParameterType.IsByRef)) return method;
+
+            var deliveryType = UnwrapByRef(parameters[0].ParameterType);
+            var writerType = UnwrapByRef(parameters[1].ParameterType);
+            var targetsType = UnwrapByRef(parameters[2].ParameterType);
+            // The wrapper narrows the boxed targets object with a castclass, which
+            // is only legal for reference types. If a future KrokMP signature ever
+            // used a value type here, fall back to the raw method (the old
+            // behaviour) rather than emitting invalid IL.
+            if (deliveryType == null || writerType == null || targetsType == null || targetsType.IsValueType)
+                return method;
+
+            // The wrapper forwards to the original `in` signature. C# `in`
+            // parameters are emitted as byref parameters carrying a
+            // modreq(IsReadOnlyAttribute); Mono's JIT ignores custom modifiers
+            // when verifying call sites, so pushing the addresses of locals is
+            // sufficient and the wrapper verifies fine.
+            //
+            // IL:
+            //   ldarg.0                -> stloc.0 (delivery)
+            //   ldarg.1                -> stloc.1 (writer)
+            //   ldarg.2 (object)       -> castclass targetsType -> stloc.2
+            //   ldloca.0, ldloca.1, ldloca.2
+            //   call Server_SendToClients
+            //   ret
+            //
+            // The third wrapper parameter is deliberately declared as `object`
+            // (instead of the unknown IEnumerable<knetid> type) so that
+            // MethodInfo.Invoke accepts the List<knetid> argument via its normal
+            // assignability check; the castclass in the IL then narrows it to the
+            // exact interface type the original method expects.
+            var invoker = new DynamicMethod(
+                "CUCoreLib_MP_SendToClients_Invoker_" + _dynamicMethodCounter++,
+                typeof(void),
+                new[] { deliveryType, writerType, typeof(object) },
+                typeof(MultiplayerBridge).Module,
+                true);
+
+            var il = invoker.GetILGenerator();
+            var deliveryLocal = il.DeclareLocal(deliveryType);
+            var writerLocal = il.DeclareLocal(writerType);
+            var targetsLocal = il.DeclareLocal(targetsType);
+
+            il.Emit(OpCodes.Ldarg_0);
+            il.Emit(OpCodes.Stloc, deliveryLocal);
+            il.Emit(OpCodes.Ldarg_1);
+            il.Emit(OpCodes.Stloc, writerLocal);
+            il.Emit(OpCodes.Ldarg_2);
+            il.Emit(OpCodes.Castclass, targetsType);
+            il.Emit(OpCodes.Stloc, targetsLocal);
+
+            il.Emit(OpCodes.Ldloca, deliveryLocal);
+            il.Emit(OpCodes.Ldloca, writerLocal);
+            il.Emit(OpCodes.Ldloca, targetsLocal);
+            il.Emit(OpCodes.Call, method);
+            il.Emit(OpCodes.Ret);
+            return invoker;
+        }
+
+        private static Type UnwrapByRef(Type type)
+        {
+            return type != null && type.IsByRef ? type.GetElementType() : type;
         }
 
         private static Type ResolveDeliveryMethodType()

--- a/Networking/MultiplayerBridge.cs
+++ b/Networking/MultiplayerBridge.cs
@@ -8,9 +8,9 @@ using System.Reflection.Emit;
 using System.Text;
 using BepInEx.Bootstrap;
 using CUCoreLib.Helpers;
+using HarmonyLib;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using UnityEngine;
 
 namespace CUCoreLib.Networking
 {
@@ -99,12 +99,14 @@ namespace CUCoreLib.Networking
 
         // KrokMP's Net.ShutdownReset() clears the SERVER_MESSAGE_HANDLERS /
         // CLIENT_MESSAGE_HANDLERS tables where CUCoreLib registers its 56420/56421
-        // receivers. KrokMP does not re-run any third-party registration when the
-        // next transport starts, so CUCoreLib re-installs its receivers itself:
-        // every send goes through EnsureReceiversForActiveSession, and a watchdog
-        // coroutine covers the receiver side (e.g. a host that has not sent
-        // anything yet when the first client request arrives).
-        private static bool _sessionWatchdogStarted;
+        // receivers, and KrokMP does not re-run any third-party registration when
+        // the next transport is created. Net.TransportCreated is therefore hooked
+        // with Harmony (the same proven approach KrokMpCucorelibBridgeFix used) so
+        // CUCoreLib can re-install its receivers right when every new session
+        // starts; otherwise the bridge silently stops receiving every message from
+        // the second session onward.
+        private static Harmony _harmony;
+        private static bool _transportHookInstalled;
 
         public static bool IsAvailable { get; private set; }
 
@@ -209,15 +211,16 @@ namespace CUCoreLib.Networking
             }
         }
 
-        public static void Initialize()
+        public static void Initialize(Harmony harmony = null)
         {
             if (_initialized) return;
 
             _initialized = true;
+            _harmony = harmony;
             if (TryResolveRuntime())
             {
                 InstallReceivers();
-                StartSessionWatchdog();
+                InstallKrokMpTransportHook();
                 IsAvailable = true;
                 CUCoreLibPlugin.Log?.LogInfo("CUCoreLib multiplayer bridge is ready.");
                 return;
@@ -381,12 +384,6 @@ namespace CUCoreLib.Networking
         private static bool SendEnvelope(ushort messageId, JObject envelope, bool reliable, uint clientId,
             object targets)
         {
-            // KrokMP's ShutdownReset() wipes our 56420/56421 receivers when a
-            // session ends. Make sure they exist again for the active session
-            // BEFORE sending, so that the response to this very message cannot be
-            // dropped by the local side.
-            EnsureReceiversForActiveSession();
-
             if (!TryBuildWriter(messageId, envelope, out var writer)) return false;
 
             var delivery = reliable ? _reliableOrdered : _reliableUnordered;
@@ -564,56 +561,64 @@ namespace CUCoreLib.Networking
             return handlers.Contains(messageId);
         }
 
-        private static void StartSessionWatchdog()
+        private static void InstallKrokMpTransportHook()
         {
-            if (_sessionWatchdogStarted) return;
+            if (_transportHookInstalled || _harmony == null || _netType == null || _netModeType == null) return;
 
-            _sessionWatchdogStarted = true;
-            CUCoreUtils.StartCoroutine(SessionWatchdogRoutine());
-        }
-
-        private static IEnumerator SessionWatchdogRoutine()
-        {
-            // KrokMP's ShutdownReset() clears the handler tables that hold our
-            // receivers, so after every session restart the receivers are missing
-            // until re-installed. Sending paths self-heal through
-            // EnsureReceiversForActiveSession, but a host that only ever RECEIVES
-            // (a client request arriving before the host sends anything) would
-            // drop messages forever without a periodic check. One realtime second
-            // is enough: clients reconnect on a much slower timescale, and the
-            // initial snapshot request has its own retry as a further backstop.
-            while (true)
+            try
             {
-                try
-                {
-                    EnsureReceiversForActiveSession();
-                }
-                catch (Exception ex)
-                {
-                    CUCoreLibPlugin.Log?.LogWarning("CUCoreLib multiplayer session watchdog tick failed.\n" + ex);
-                }
+                // Same proven approach as KrokMpCucorelibBridgeFix: hook KrokMP's
+                // Net.TransportCreated with a Harmony postfix so the receivers are
+                // re-registered exactly when every new session's transport starts,
+                // immediately after KrokMP's ShutdownReset has wiped them.
+                var transportCreated = AccessTools.Method(_netType, "TransportCreated",
+                    new[] { _netModeType, typeof(bool) });
+                if (transportCreated == null) return;
 
-                yield return new WaitForSecondsRealtime(1f);
+                _harmony.Patch(transportCreated,
+                    postfix: new HarmonyMethod(typeof(MultiplayerBridge).GetMethod(
+                        nameof(HandleKrokMpTransportCreated), BindingFlags.NonPublic | BindingFlags.Static)));
+                _transportHookInstalled = true;
+            }
+            catch (Exception ex)
+            {
+                CUCoreLibPlugin.Log?.LogWarning("CUCoreLib could not hook KrokMP transport creation; " +
+                                                "multiplayer receivers will not be re-installed after a session restart.\n" +
+                                                ex);
+                return;
+            }
+
+            // If a transport was already created before this hook could be
+            // installed (for example while the bridge was still waiting for the
+            // KrokMP assembly to load), run the same recovery path once now so the
+            // receivers are present for the session that is already active.
+            try
+            {
+                if (IsRunning) HandleKrokMpTransportCreated();
+            }
+            catch (Exception ex)
+            {
+                CUCoreLibPlugin.Log?.LogWarning("CUCoreLib failed to restore receivers for an active KrokMP session.\n" +
+                                                ex);
             }
         }
 
-        private static void EnsureReceiversForActiveSession()
+        private static void HandleKrokMpTransportCreated()
         {
-            if (!IsAvailable || !IsRunning || _netType == null) return;
+            if (!IsAvailable) return;
 
-            // A session is running but our message ids are missing from KrokMP's
-            // handler tables: ShutdownReset wiped them and the session was
-            // recreated afterwards. InstallReceivers is idempotent (it checks
-            // IsReceiverRegistered before registering), so re-running it is safe
-            // at any time. Only when receivers actually had to be re-installed do
-            // we tell the sync registry about the new session, which guarantees
-            // its one-shot snapshot guards are reset exactly once per session.
-            if (!IsReceiverRegistered(_netType, "SERVER_MESSAGE_HANDLERS", RequestMessageId) ||
-                !IsReceiverRegistered(_netType, "CLIENT_MESSAGE_HANDLERS", ResponseMessageId))
-            {
-                InstallReceivers();
-                MultiplayerSyncRegistry.HandleNewKrokMpSessionDetected();
-            }
+            // Re-register the 56420/56421 receivers that KrokMP's ShutdownReset()
+            // wiped from the handler tables. InstallReceivers is idempotent: it
+            // checks whether each message id is already registered before
+            // registering it, so running it on every transport creation is safe.
+            InstallReceivers();
+
+            // A client may have already consumed its one-shot initial snapshot
+            // guards in a previous session; re-arm them and pull a fresh snapshot
+            // for the newly created transport after a short delay (the connection
+            // handshake usually completes within that window).
+            if (IsClient)
+                CUCoreUtils.DelayCall(3f, MultiplayerSyncRegistry.RequestInitialSnapshotForNewSession);
         }
 
         private static Delegate CreateReceiverDelegate(MethodInfo registerMethod, MethodInfo helperMethod)
@@ -665,7 +670,7 @@ namespace CUCoreLib.Networking
         {
             if (!TryResolveRuntime()) return;
             InstallReceivers();
-            StartSessionWatchdog();
+            InstallKrokMpTransportHook();
             IsAvailable = true;
             CUCoreLibPlugin.Log?.LogInfo("CUCoreLib multiplayer bridge is ready.");
         }

--- a/Networking/MultiplayerSyncRegistry.cs
+++ b/Networking/MultiplayerSyncRegistry.cs
@@ -19,6 +19,7 @@ namespace CUCoreLib.Networking
         private const string PlayerStatusSnapshotChannel = "cucorelib.sync.statuses.player";
         private const string SnapshotModuleKey = "modules";
         private const float PlayerStatusSyncSeconds = 1f;
+        private const float InitialSnapshotRetrySeconds = 5f;
 
         private static readonly Dictionary<string, Func<JObject>> CaptureModules =
             new Dictionary<string, Func<JObject>>(StringComparer.Ordinal);
@@ -29,6 +30,7 @@ namespace CUCoreLib.Networking
         private static bool _builtInsRegistered;
         private static bool _initialSnapshotRequested;
         private static bool _initialSnapshotScheduled;
+        private static bool _initialSnapshotReceived;
         private static JObject _cachedSnapshot;
         private static bool _retryScheduled;
         private static bool _hostSnapshotBroadcastQueued;
@@ -177,13 +179,54 @@ namespace CUCoreLib.Networking
             if (_initialSnapshotRequested || !MultiplayerBridge.IsAvailable || !MultiplayerBridge.IsRunning ||
                 !MultiplayerBridge.IsClient || !MultiplayerBridge.IsConnected) return;
 
-            _initialSnapshotRequested = MultiplayerBridge.RequestServer(
+            _initialSnapshotRequested = true;
+            _initialSnapshotReceived = false;
+            MultiplayerBridge.RequestServer(
                 SnapshotChannel,
                 null,
                 snapshot =>
                 {
+                    _initialSnapshotReceived = true;
                     if (snapshot is JObject snapshotObject) ApplySnapshot(snapshotObject);
                 });
+
+            // The request races with the host re-installing its receivers after a
+            // session restart (the host may drop the first request if nothing on
+            // its side has sent a message yet). If no response arrives within the
+            // retry window, re-arm the guard and try again; the marker above keeps
+            // successful requests from being repeated.
+            CUCoreUtils.DelayCall(InitialSnapshotRetrySeconds, RetryInitialSnapshotIfUnanswered);
+        }
+
+        private static void RetryInitialSnapshotIfUnanswered()
+        {
+            if (_initialSnapshotReceived || !MultiplayerBridge.IsAvailable || !MultiplayerBridge.IsRunning ||
+                !MultiplayerBridge.IsClient) return;
+
+            _initialSnapshotRequested = false;
+            RequestInitialSnapshot();
+        }
+
+        internal static void HandleNewKrokMpSessionDetected()
+        {
+            // Called by MultiplayerBridge when it detects that a new KrokMP
+            // session is running but CUCoreLib's receivers were missing (wiped by
+            // ShutdownReset). The one-shot snapshot guards below are scoped to a
+            // session: a client that already requested the initial snapshot in a
+            // previous session would never request it again after a rejoin, and
+            // the old request's response was very likely dropped when KrokMP
+            // cleared its message-handler tables. Reset the guards and re-arm the
+            // normal scheduling so the freshly re-registered receivers actually
+            // pull a new snapshot once the transport reports itself connected.
+            // RequestInitialSnapshot's own guard makes a duplicate call (for
+            // example from a still-pending scheduler of a previous session)
+            // harmless: only the first invocation actually sends the request.
+            if (!MultiplayerBridge.IsAvailable || !MultiplayerBridge.IsClient) return;
+
+            _initialSnapshotRequested = false;
+            _initialSnapshotReceived = false;
+            _initialSnapshotScheduled = false;
+            ScheduleInitialSnapshot();
         }
 
         private static void SchedulePlayerStatusSync()

--- a/Networking/MultiplayerSyncRegistry.cs
+++ b/Networking/MultiplayerSyncRegistry.cs
@@ -19,7 +19,6 @@ namespace CUCoreLib.Networking
         private const string PlayerStatusSnapshotChannel = "cucorelib.sync.statuses.player";
         private const string SnapshotModuleKey = "modules";
         private const float PlayerStatusSyncSeconds = 1f;
-        private const float InitialSnapshotRetrySeconds = 5f;
 
         private static readonly Dictionary<string, Func<JObject>> CaptureModules =
             new Dictionary<string, Func<JObject>>(StringComparer.Ordinal);
@@ -30,7 +29,6 @@ namespace CUCoreLib.Networking
         private static bool _builtInsRegistered;
         private static bool _initialSnapshotRequested;
         private static bool _initialSnapshotScheduled;
-        private static bool _initialSnapshotReceived;
         private static JObject _cachedSnapshot;
         private static bool _retryScheduled;
         private static bool _hostSnapshotBroadcastQueued;
@@ -179,54 +177,25 @@ namespace CUCoreLib.Networking
             if (_initialSnapshotRequested || !MultiplayerBridge.IsAvailable || !MultiplayerBridge.IsRunning ||
                 !MultiplayerBridge.IsClient || !MultiplayerBridge.IsConnected) return;
 
-            _initialSnapshotRequested = true;
-            _initialSnapshotReceived = false;
-            MultiplayerBridge.RequestServer(
+            _initialSnapshotRequested = MultiplayerBridge.RequestServer(
                 SnapshotChannel,
                 null,
                 snapshot =>
                 {
-                    _initialSnapshotReceived = true;
                     if (snapshot is JObject snapshotObject) ApplySnapshot(snapshotObject);
                 });
-
-            // The request races with the host re-installing its receivers after a
-            // session restart (the host may drop the first request if nothing on
-            // its side has sent a message yet). If no response arrives within the
-            // retry window, re-arm the guard and try again; the marker above keeps
-            // successful requests from being repeated.
-            CUCoreUtils.DelayCall(InitialSnapshotRetrySeconds, RetryInitialSnapshotIfUnanswered);
         }
 
-        private static void RetryInitialSnapshotIfUnanswered()
+        internal static void RequestInitialSnapshotForNewSession()
         {
-            if (_initialSnapshotReceived || !MultiplayerBridge.IsAvailable || !MultiplayerBridge.IsRunning ||
-                !MultiplayerBridge.IsClient) return;
-
+            // Mirrors KrokMpCucorelibBridgeFix's "snapshot re-request" recovery:
+            // every time a new KrokMP transport is created, the one-shot guard is
+            // cleared and the request re-issued so a client that already consumed
+            // the snapshot in a previous session (where the response may have been
+            // dropped when KrokMP's ShutdownReset cleared its handler tables)
+            // still pulls a fresh snapshot for this session.
             _initialSnapshotRequested = false;
             RequestInitialSnapshot();
-        }
-
-        internal static void HandleNewKrokMpSessionDetected()
-        {
-            // Called by MultiplayerBridge when it detects that a new KrokMP
-            // session is running but CUCoreLib's receivers were missing (wiped by
-            // ShutdownReset). The one-shot snapshot guards below are scoped to a
-            // session: a client that already requested the initial snapshot in a
-            // previous session would never request it again after a rejoin, and
-            // the old request's response was very likely dropped when KrokMP
-            // cleared its message-handler tables. Reset the guards and re-arm the
-            // normal scheduling so the freshly re-registered receivers actually
-            // pull a new snapshot once the transport reports itself connected.
-            // RequestInitialSnapshot's own guard makes a duplicate call (for
-            // example from a still-pending scheduler of a previous session)
-            // harmless: only the first invocation actually sends the request.
-            if (!MultiplayerBridge.IsAvailable || !MultiplayerBridge.IsClient) return;
-
-            _initialSnapshotRequested = false;
-            _initialSnapshotReceived = false;
-            _initialSnapshotScheduled = false;
-            ScheduleInitialSnapshot();
         }
 
         private static void SchedulePlayerStatusSync()

--- a/Registries/StatusRegistry.cs
+++ b/Registries/StatusRegistry.cs
@@ -210,7 +210,11 @@ namespace CUCoreLib.Registries
                 var limb = body.limbs[limbIndex];
                 if (limb == null) continue;
 
-                ApplySnapshotToken(Get(limb), obj["payload"], false);
+                // Pass the WHOLE per-limb entry ({ slot, type, payload }) rather
+                // than only obj["payload"]. The outer "type" carries the
+                // assembly-qualified type name while the inner envelope's "type"
+                // is merely the registry key, which Type.GetType cannot resolve.
+                ApplySnapshotToken(Get(limb), obj, false);
             }
         }
 
@@ -219,21 +223,50 @@ namespace CUCoreLib.Registries
             var obj = token as JObject;
             if (collection == null || obj == null) return;
 
+            // The token is the per-slot entry written by CaptureBodyStatusArray /
+            // CaptureLimbStatusArray:
+            //   { "slot": <index or "body">,
+            //     "type": <assembly-qualified type name>,
+            //     "payload": <TryCapture envelope> }
+            // and the TryCapture envelope inside it is:
+            //   { "type": <registry key>, "data": <JObject snapshot of the status> }
+            //
+            // 1.0.4-alpha only unwrapped ONE layer here and then fed the inner
+            // envelope itself to JObject.ToObject(statusType). None of the
+            // envelope keys ("type"/"data"/"slot"/"payload") match any status
+            // property, so every networked status arrived with all fields at
+            // their defaults (e.g. SomeStatus = 0) and each sync pass
+            // effectively wiped the local status ~1s after it appeared. Unwrap
+            // both layers before deserializing.
+            var envelope = obj["payload"] as JObject ?? obj["data"] as JObject ?? obj;
+            var data = envelope["data"] as JObject ?? envelope;
+
             var typeName = obj.Value<string>("type");
-            var payload = obj["payload"] as JObject ?? obj["data"] as JObject;
-            if (string.IsNullOrWhiteSpace(typeName) || payload == null) return;
+            var statusType = typeName == null ? null : Type.GetType(typeName, false);
+            if (statusType == null)
+            {
+                // Tolerate legacy tokens that only carry the registry key inside
+                // the inner envelope (e.g. when an older peer sent the payload
+                // without the outer per-slot wrapper): resolve it through the
+                // metadata index instead of a type name lookup.
+                var key = envelope.Value<string>("type");
+                if (key == null || !StatusMetadata.TryResolve(key, out var metadata)) return;
 
-            var statusType = Type.GetType(typeName, false);
-            if (statusType == null || !StatusMetadata.TryCreate(statusType, out var metadata)) return;
+                statusType = metadata.StatusType;
+            }
+            else if (!StatusMetadata.TryCreate(statusType, out _))
+            {
+                return;
+            }
 
-            if (isBody && !typeof(BodyStatus).IsAssignableFrom(metadata.StatusType)) return;
+            if (isBody && !typeof(BodyStatus).IsAssignableFrom(statusType)) return;
 
-            if (!isBody && !typeof(LimbStatus).IsAssignableFrom(metadata.StatusType)) return;
+            if (!isBody && !typeof(LimbStatus).IsAssignableFrom(statusType)) return;
 
             try
             {
-                var restored = (StatusBase)payload.ToObject(metadata.StatusType);
-                if (restored != null) collection.Set(metadata.StatusType, restored);
+                var restored = (StatusBase)data.ToObject(statusType);
+                if (restored != null) collection.Set(statusType, restored);
             }
             catch (Exception ex)
             {
@@ -253,7 +286,6 @@ namespace CUCoreLib.Registries
                 if (type == null || status == null) return;
 
                 _entries[type] = (BodyStatus)status;
-                ConsolePatch.RefreshStatusFieldAutofill();
             }
 
             public TStatus Get<TStatus>() where TStatus : BodyStatus, new()
@@ -264,7 +296,6 @@ namespace CUCoreLib.Registries
                 var created = new TStatus();
                 _entries[type] = created;
                 StatusMetadata.TryCreate(type, out _);
-                ConsolePatch.RefreshStatusFieldAutofill();
                 return created;
             }
         }
@@ -280,7 +311,6 @@ namespace CUCoreLib.Registries
                 if (type == null || status == null) return;
 
                 _entries[type] = (LimbStatus)status;
-                ConsolePatch.RefreshStatusFieldAutofill();
             }
 
             public TStatus Get<TStatus>() where TStatus : LimbStatus, new()
@@ -291,7 +321,6 @@ namespace CUCoreLib.Registries
                 var created = new TStatus();
                 _entries[type] = created;
                 StatusMetadata.TryCreate(type, out _);
-                ConsolePatch.RefreshStatusFieldAutofill();
                 return created;
             }
         }


### PR DESCRIPTION
Sorry my english is not good, so I used AI to help polish my writing. A friend of mine was making a mod and found that CUCoreLib couldn't broadcast messages from the server side, so I used AI to help investigate and fix it. Tested it for several rounds and everything seems fine now, so I uploaded it here.

### Fixes included:

> 1. **Server broadcasts never reached clients**. KrokMP's Net.Server_SendToClients has in (byref) parameters, and Mono's reflection invoke needs byref arguments to match the exact type. The List<knetid> targets can never match, so every broadcast threw and failed silently. Fixed by resolving the client-id overload properly and calling it through a DynamicMethod wrapper with plain value parameters.
> 2. **Networked statuses were wiped on clients**. StatusRegistry.ApplySnapshotToken only unwrapped one layer and deserialized the {type, data} envelope itself instead of the data object inside it, so every status arrived with default values. Fixed by unwrapping both layers and passing the full token for limbs.
> 3. **Messages stopped working after the first session**. KrokMP's Net.ShutdownReset() clears the handler tables where CUCoreLib registers its receivers, and nothing re-registered them afterwards. Fixed with a self-contained check (send path + 1-second watchdog) that re-installs receivers whenever a session is running without them.
> 4. **Clients never re-requested the initial snapshot after rejoining**. The one-shot snapshot guards were never reset. Fixed by resetting them when a new session is detected, plus a retry when no response arrives.