### PR TITLE
fix: Unintended battery init mark

### DIFF
--- a/Helpers/CustomInstantiate.cs
+++ b/Helpers/CustomInstantiate.cs
@@ -67,7 +67,7 @@ namespace CUCoreLib.Helpers
             return vanilla != null ? vanilla : GetOrCreateTemplate(id);
         }
 
-        internal static GameObject PrepareInstantiatedObject(GameObject obj, float? condition = null)
+        internal static GameObject PrepareInstantiatedObject(GameObject obj, float? condition = null, bool save = false)
         {
             if (obj == null) return null;
 
@@ -78,7 +78,8 @@ namespace CUCoreLib.Helpers
                 // Matches vanilla's throw path so custom sprite colliders do not tunnel through terrain.
                 if (ItemRegistry.TryGetCustomInfo(item, out _) && item.rb != null)
                     item.rb.collisionDetectionMode = CollisionDetectionMode2D.Continuous;
-                ItemRegistryPatches.MarkPendingBatteryInitialization(obj);
+                if(!save)
+                    ItemRegistryPatches.MarkPendingBatteryInitialization(obj);
             }
 
             if (!condition.HasValue) return obj;

--- a/Patches/CustomItemSerializationPatches.cs
+++ b/Patches/CustomItemSerializationPatches.cs
@@ -22,7 +22,7 @@ namespace CUCoreLib.Patches
             var clone = Object.Instantiate(original, position, rotation);
             if (clone is GameObject obj)
             {
-                CustomInstantiate.PrepareInstantiatedObject(obj);
+                CustomInstantiate.PrepareInstantiatedObject(obj, save: true);
 
                 // Apply registered runtime properties (container capacity etc.) immediately:
                 // TryLoadGame refills containers via Container.LoadItem in this same frame,


### PR DESCRIPTION
Unsure about the pipeline but judging from the `ApplyBatteryProperties` function, from tag `v1.0.3-alpha` to `v1.0.4-alpha` and the results from this patch, save items weren't intended to be marked.